### PR TITLE
Corrected mixed indentation in notification.c

### DIFF
--- a/libnotify/notification.c
+++ b/libnotify/notification.c
@@ -151,11 +151,11 @@ notify_notification_class_init (NotifyNotificationClass *klass)
         object_class->finalize = notify_notification_finalize;
 
         /**
-	 * NotifyNotification::closed:
-	 * @notification: The object which received the signal.
-	 *
-	 * Emitted when the notification is closed.
-	 */
+         * NotifyNotification::closed:
+         * @notification: The object which received the signal.
+         *
+         * Emitted when the notification is closed.
+         */
         signals[SIGNAL_CLOSED] =
                 g_signal_new ("closed",
                               G_TYPE_FROM_CLASS (object_class),


### PR DESCRIPTION
### I was making a few tweaks to libnotify for my own use, and I noticed this mixed indentation.  I know it's hard to see in the diff, but I removed the only 5 tab characters in the file and replaced them with spaces.