### PR TITLE
Handle errors from notify_notification_show()

### DIFF
--- a/tools/notify-send.c
+++ b/tools/notify-send.c
@@ -133,6 +133,7 @@ main (int argc, char *argv[])
         static char       **hints = NULL;
         static gboolean     do_version = FALSE;
         static gboolean     hint_error = FALSE;
+        static gboolean     show_error = FALSE;
         static glong        expire_timeout = NOTIFY_EXPIRES_DEFAULT;
         GOptionContext     *opt_ctx;
         NotifyNotification *notify;
@@ -274,12 +275,18 @@ main (int argc, char *argv[])
                 }
         }
 
-        if (!hint_error)
-                notify_notification_show (notify, NULL);
+        if (!hint_error) {
+                retval = notify_notification_show (notify, &error);
+                if (!retval) {
+                        fprintf (stderr, "%s\n", error->message);
+                        g_error_free (error);
+                        show_error = TRUE;
+                }
+        }
 
         g_object_unref (G_OBJECT (notify));
 
         notify_uninit ();
 
-        exit (hint_error);
+        exit (hint_error || show_error);
 }


### PR DESCRIPTION
*notify-send* ignores errors from `notify_notification_show()`. This is a proposal to fix it and to report the error to the user.